### PR TITLE
Chart Double Click

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "recharts",
-  "version": "1.8.5",
+  "version": "2.0.0-beta.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -5791,7 +5791,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5812,12 +5813,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5832,17 +5835,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5959,7 +5965,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5971,6 +5978,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5985,6 +5993,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5992,12 +6001,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -6016,6 +6027,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6096,7 +6108,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6108,6 +6121,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6193,7 +6207,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6229,6 +6244,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6248,6 +6264,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6291,12 +6308,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/src/chart/Sankey.tsx
+++ b/src/chart/Sankey.tsx
@@ -344,6 +344,7 @@ class Props implements PresentationAttributes<any>, DOMAttributesWithProps<any, 
   margin: Margin = { top: 5, right: 5, bottom: 5, left: 5 };
 
   onClick: any;
+  onDoubleClick: any;
 
   onMouseEnter: any;
   onMouseLeave: any;
@@ -450,6 +451,11 @@ class Sankey extends PureComponent<Props, State> {
   handleClick(el: React.ReactElement, type: string, e: any) {
     const { onClick } = this.props;
     if (onClick) onClick(el, type, e);
+  }
+
+  handleDoubleClick(el: React.ReactElement, type: string, e: any) {
+    const { onDoubleClick } = this.props;
+    if (onDoubleClick) onDoubleClick(el, type, e);
   }
 
   static renderLinkItem(option: any, props: Props) {

--- a/src/chart/Treemap.tsx
+++ b/src/chart/Treemap.tsx
@@ -234,6 +234,7 @@ class Props {
   onMouseEnter: (node: TreemapNode, e: any) => {};
   onMouseLeave: (node: TreemapNode, e: any) => {};
   onClick: (node: TreemapNode) => {};
+  onDoubleClick: (node: TreemapNode) => {};
 
   isAnimationActive: boolean = !isSsr();
   isUpdateAnimationActive: boolean = !isSsr();
@@ -396,6 +397,33 @@ class Treemap extends PureComponent<Props, State> {
     }
     if (onClick) {
       onClick(node);
+    }
+  }
+
+  handleDoubleClick(node: TreemapNode) {
+    const { onDoubleClick, type } = this.props;
+    if (type === 'nest' && node.children) {
+      const { width, height, dataKey, aspectRatio } = this.props;
+      const root = computeNode({
+        depth: 0,
+        node: { ...node, x: 0, y: 0, width, height },
+        index: 0,
+        valueKey: dataKey,
+      });
+
+      const formatRoot = squarify(root, aspectRatio);
+
+      const { nestIndex } = this.state;
+      nestIndex.push(node);
+
+      this.setState({
+        formatRoot,
+        currentRoot: root,
+        nestIndex,
+      });
+    }
+    if (onDoubleClick) {
+      onDoubleClick(node);
     }
   }
 

--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -1079,6 +1079,16 @@ const generateCategoricalChart = ({
       }
     };
 
+    handleDoubleClick = (e: any) => {
+      const { onDoubleClick } = this.props;
+
+      if (_.isFunction(onDoubleClick)) {
+        const mouse = this.getMouseInfo(e);
+
+        onDoubleClick(mouse, e);
+      }
+    }
+
     handleMouseDown = (e: any) => {
       const { onMouseDown } = this.props;
 
@@ -1401,7 +1411,7 @@ const generateCategoricalChart = ({
 
     static renderActiveDot (option: any, props: any): React.ReactElement {
       let dot;
-    
+
       if (isValidElement(option)) {
         dot = cloneElement(option, props);
       } else if (_.isFunction(option)) {
@@ -1409,7 +1419,7 @@ const generateCategoricalChart = ({
       } else {
         dot = <Dot {...props} />;
       }
-    
+
       return (
         <Layer className="recharts-active-dot" key={props.key}>
           {dot}

--- a/src/chart/types.ts
+++ b/src/chart/types.ts
@@ -19,6 +19,7 @@ interface CategoricalChartPropTypes {
   children?: any;
   defaultShowTooltip?: boolean;
   onClick?: any;
+  onDoubleClick?: any;
   onMouseLeave?: any;
   onMouseEnter?: any;
   onMouseMove?: any;

--- a/src/component/DefaultLegendContent.tsx
+++ b/src/component/DefaultLegendContent.tsx
@@ -39,6 +39,7 @@ export interface Props<TValue, TID> {
   onMouseEnter?: (event: MouseEvent) => void;
   onMouseLeave?: (event: MouseEvent) => void;
   onClick?: (event: MouseEvent) => void;
+  onDoubleClick?: (event: MouseEvent) => void;
 }
 
 class DefaultLegendContent<TValue, TID> extends PureComponent<Props<TValue, TID>> {

--- a/src/util/ReactUtils.ts
+++ b/src/util/ReactUtils.ts
@@ -6,6 +6,7 @@ import { shallowEqual } from './ShallowEqual';
 
 const REACT_BROWSER_EVENT_MAP: any = {
   click: 'onClick',
+  doubleClick: 'onDoubleClick',
   mousedown: 'onMouseDown',
   mouseup: 'onMouseUp',
   mouseover: 'onMouseOver',


### PR DESCRIPTION
Adds a Double Click implementation for all of the charts within the library. This is implemented in the same way as the Single Click.

Also updates the `package-lock.json` with automatic changes.