### PR TITLE
Chart Double Click

### DIFF
--- a/demo/component/BarChart.js
+++ b/demo/component/BarChart.js
@@ -239,6 +239,10 @@ export default class Demo extends Component {
     console.log(`Pv Bar (${index}) Click: `, data);
   };
 
+  handleDoubleClick = (data, index, e) => {
+    console.log(`Double Click invoked on Bar (${index}): `, data);
+  }
+
   handleBarAnimationStart = () => {
     console.log('Animation start');
   };
@@ -367,6 +371,13 @@ export default class Demo extends Component {
         <div className="bar-chart-wrapper">
           <BarChart width={150} height={40} data={data}>
             <Bar dataKey="uv" fill="#ff7300" onClick={this.handlePvBarClick} background />
+          </BarChart>
+        </div>
+
+        <p>Tiny BarChart with Double Click</p>
+        <div className="bar-chart-wrapper">
+          <BarChart width={150} height={40} data={data}>
+            <Bar dataKey="uv" fill="#ff7300" onDoubleClick={this.handleDoubleClick} background />
           </BarChart>
         </div>
 

--- a/demo/component/PieChart.js
+++ b/demo/component/PieChart.js
@@ -130,6 +130,10 @@ export default class Demo extends Component {
     });
   };
 
+  handleDoubleClick = (data, index, e) => {
+    console.log(`Double Click invoked on Pie Sector ${index} with: `, data);
+  }
+
   handlePieChartEnter = (a, b, c) => {
     console.log(a, b, c);
   };
@@ -164,6 +168,7 @@ export default class Demo extends Component {
               endAngle={0}
               outerRadius={80}
               label
+              onDoubleClick={this.handleDoubleClick}
             >
               {
                 data01.map((entry, index) => (
@@ -275,4 +280,3 @@ export default class Demo extends Component {
     );
   }
 }
-

--- a/src/chart/Sankey.js
+++ b/src/chart/Sankey.js
@@ -444,6 +444,11 @@ class Sankey extends PureComponent {
     if (onClick) onClick(el, type, e);
   }
 
+  handleDoubleClick(el, type, e) {
+    const { onDoubleClick } = this.props;
+    if (onDoubleClick) onDoubleClick(el, type, e);
+  }
+
   static renderLinkItem(option, props) {
     if (React.isValidElement(option)) {
       return React.cloneElement(option, props);

--- a/src/chart/Treemap.js
+++ b/src/chart/Treemap.js
@@ -430,6 +430,7 @@ class Treemap extends PureComponent {
         onMouseEnter: this.handleMouseEnter.bind(this, nodeProps),
         onMouseLeave: this.handleMouseLeave.bind(this, nodeProps),
         onClick: this.handleClick.bind(this, nodeProps),
+        onDoubleClick: this.handleDoubleClick.bind(this, nodeProps),
       };
     }
 

--- a/src/chart/generateCategoricalChart.js
+++ b/src/chart/generateCategoricalChart.js
@@ -73,6 +73,7 @@ const generateCategoricalChart = ({
       ]),
       defaultShowTooltip: PropTypes.bool,
       onClick: PropTypes.func,
+      onDoubleClick: PropTypes.func,
       onMouseLeave: PropTypes.func,
       onMouseEnter: PropTypes.func,
       onMouseMove: PropTypes.func,
@@ -1066,6 +1067,16 @@ const generateCategoricalChart = ({
         const mouse = this.getMouseInfo(e);
 
         onClick(mouse, e);
+      }
+    };
+
+    handleDoubleClick = (e) => {
+      const { onDoubleClick } = this.props;
+
+      if (_.isFunction(onDoubleClick)) {
+        const mouse = this.getMouseInfo(e);
+
+        onDoubleClick(mouse, e);
       }
     };
 

--- a/src/component/DefaultLegendContent.js
+++ b/src/component/DefaultLegendContent.js
@@ -31,6 +31,7 @@ class DefaultLegendContent extends PureComponent {
     onMouseEnter: PropTypes.func,
     onMouseLeave: PropTypes.func,
     onClick: PropTypes.func,
+    onDoubleClick: PropTypes.func,
   };
 
   static defaultProps = {

--- a/src/component/Legend.js
+++ b/src/component/Legend.js
@@ -66,6 +66,7 @@ class Legend extends PureComponent {
     onMouseEnter: PropTypes.func,
     onMouseLeave: PropTypes.func,
     onClick: PropTypes.func,
+    onDoubleClick: PropTypes.func,
     onBBoxUpdate: PropTypes.func,
   };
 

--- a/src/component/Text.js
+++ b/src/component/Text.js
@@ -58,7 +58,7 @@ class Text extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    if (prevProps.width !== this.props.width || prevProps.scaleToFit !== this.props.scaleToFit || 
+    if (prevProps.width !== this.props.width || prevProps.scaleToFit !== this.props.scaleToFit ||
       prevProps.children !== this.props.children || prevProps.style !== this.props.style) {
       const needCalculate = (
         this.props.children !== prevProps.children ||

--- a/src/polar/Radar.js
+++ b/src/polar/Radar.js
@@ -57,6 +57,7 @@ class Radar extends PureComponent {
     onMouseEnter: PropTypes.func,
     onMouseLeave: PropTypes.func,
     onClick: PropTypes.func,
+    onDoubleClick: PropTypes.func,
     isAnimationActive: PropTypes.bool,
     animationId: PropTypes.number,
     animationBegin: PropTypes.number,

--- a/src/polar/RadialBar.js
+++ b/src/polar/RadialBar.js
@@ -59,6 +59,7 @@ class RadialBar extends PureComponent {
     onMouseEnter: PropTypes.func,
     onMouseLeave: PropTypes.func,
     onClick: PropTypes.func,
+    onDoubleClick: PropTypes.func,
 
     isAnimationActive: PropTypes.bool,
     animationBegin: PropTypes.number,

--- a/src/util/ReactUtils.js
+++ b/src/util/ReactUtils.js
@@ -160,6 +160,7 @@ export const PRESENTATION_ATTRIBUTES = {
 
 export const EVENT_ATTRIBUTES = {
   onClick: PropTypes.func,
+  onDoubleClick: PropTypes.func,
   onMouseDown: PropTypes.func,
   onMouseUp: PropTypes.func,
   onMouseOver: PropTypes.func,
@@ -175,6 +176,7 @@ export const EVENT_ATTRIBUTES = {
 
 const REACT_BROWSER_EVENT_MAP = {
   click: 'onClick',
+  dblclick: 'onDoubleClick',
   mousedown: 'onMouseDown',
   mouseup: 'onMouseUp',
   mouseover: 'onMouseOver',

--- a/test/specs/chart/BarChartSpec.js
+++ b/test/specs/chart/BarChartSpec.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { expect } from 'chai';
 import { BarChart, Bar, XAxis, YAxis, Tooltip } from 'recharts';
 import { mount, render } from 'enzyme';
+import sinon from 'sinon';
 
 describe('<BarChart />', () => {
   const data = [
@@ -166,4 +167,28 @@ describe('<BarChart />', () => {
     expect(wrapper.find('.customized-shape').length).to.equal(4);
   });
 
+  it('click on bar chart should invoke onClick callback', () => {
+    const onClick = sinon.spy();
+    const wrapper = mount(
+      <BarChart width={100} height={50} data={data} onClick={onClick}>
+        <Bar dataKey="uv" label fill="#ff7300" />
+      </BarChart>
+    );
+
+    const bar = wrapper.find(Bar);
+    bar.simulate('click');
+    expect(onClick.calledOnce).to.equal(true);
+  });
+
+  it('double click on bar chart should invoke onDoubleClick callback', () => {
+    const onDoubleClick = sinon.spy();
+    const wrapper = mount(
+      <BarChart width={100} height={50} data={data} onDoubleClick={onDoubleClick}>
+        <Bar dataKey="uv" label fill="#ff7300" />
+      </BarChart>
+    );
+
+    wrapper.instance().props.onDoubleClick();
+    expect(onDoubleClick.calledOnce).to.equal(true);
+  });
 });

--- a/test/specs/chart/LineChartSpec.js
+++ b/test/specs/chart/LineChartSpec.js
@@ -307,6 +307,18 @@ describe('<LineChart />', () => {
     expect(eventOfCallback).to.include.all.keys(['currentTarget', 'target']);
   });
 
+  it('double clicking on Curve should invoke onDoubleClick callback', () => {
+    const onDoubleClick = sinon.spy();
+    const wrapper = mount(
+      <LineChart width={400} height={400} data={data} margin={{ top: 20, right: 20, bottom: 20, left: 20 }}>
+        <Line onDoubleClick={onDoubleClick} type="monotone" dataKey="uv" stroke="#ff7300" />
+      </LineChart>
+    );
+    const curve = wrapper.find(Curve);
+    curve.simulate('dblclick');
+    expect(onDoubleClick.calledOnce).to.equal(true);
+  });
+
   it('should show tooltip cursor on MouseEnter and MouseMove and hide on MouseLeave', () => {
     const margin = { top: 20, right: 20, bottom: 20, left: 20 };
     const height = 400;

--- a/test/specs/chart/PieChartSpec.js
+++ b/test/specs/chart/PieChartSpec.js
@@ -130,4 +130,20 @@ describe('<PieChart />', () => {
     expect(onMouseLeave.calledOnce).to.equal(true);
     */
   });
+
+  it('double click should invoke onDoubleClick callback', () => {
+    const onDoubleClick = sinon.spy();
+    const wrapper = mount(
+      <PieChart
+        width={800}
+        height={400}
+        onDoubleClick={onDoubleClick}
+      >
+        <Pie dataKey="value" isAnimationActive={false} data={data} cx={200} cy={200} outerRadius={80} fill="#ff7300" label />
+      </PieChart>
+    );
+
+    wrapper.instance().props.onDoubleClick();
+    expect(onDoubleClick.calledOnce).to.equal(true);
+  });
 });

--- a/test/specs/chart/ScatterChartSpec.js
+++ b/test/specs/chart/ScatterChartSpec.js
@@ -3,6 +3,7 @@ import { expect } from 'chai';
 import { ScatterChart, Scatter, CartesianGrid, Tooltip, XAxis, YAxis, ZAxis,
   CartesianAxis, Legend, Cross, Symbols } from 'recharts';
 import { mount, render } from 'enzyme';
+import sinon from 'sinon';
 
 describe('ScatterChart of three dimension data', () => {
   const data01 = [
@@ -92,8 +93,8 @@ describe('ScatterChart of two dimension data', () => {
 
   const wrapper = render(
     <ScatterChart width={400} height={400} margin={{ top: 20, right: 20, bottom: 20, left: 20 }}>
-      <XAxis dataKey={'x'} name="stature" unit="cm" />
-      <YAxis dataKey={'y'} name="weight" unit="kg" />
+      <XAxis dataKey="x" name="stature" unit="cm" />
+      <YAxis dataKey="y" name="weight" unit="kg" />
       <Scatter line name="A school" data={data} fill="#ff7300" />
     </ScatterChart>
   );
@@ -105,4 +106,31 @@ describe('ScatterChart of two dimension data', () => {
     expect(wrapper.find('.recharts-scatter-line').length).to.equal(1);
   });
 
+  it('click on scatter chart should invoke onClick callback', () => {
+    const onClick = sinon.spy();
+    const mountedWrapper = mount(
+      <ScatterChart width={400} height={400} margin={{ top: 20, right: 20, bottom: 20, left: 20 }} onClick={onClick}>
+        <XAxis dataKey="x" name="stature" unit="cm" />
+        <YAxis dataKey="y" name="weight" unit="kg" />
+        <Scatter line name="A school" data={data} fill="#ff7300" />
+      </ScatterChart>
+    );
+
+    const scatter = mountedWrapper.find(Scatter);
+    scatter.simulate('click');
+    expect(onClick.calledOnce).to.equal(true);
+  });
+
+  it('double click on scatter chart should invoke onDoubleClick callback', () => {
+    const onDoubleClick = sinon.spy();
+    const mountedWrapper = mount(
+      <ScatterChart width={400} height={400} margin={{ top: 20, right: 20, bottom: 20, left: 20 }} onDoubleClick={onDoubleClick}>
+        <XAxis dataKey="x" name="stature" unit="cm" />
+        <YAxis dataKey="y" name="weight" unit="kg" />
+        <Scatter line name="A school" data={data} fill="#ff7300" />
+      </ScatterChart>
+    );
+    mountedWrapper.instance().props.onDoubleClick();
+    expect(onDoubleClick.calledOnce).to.equal(true);
+  });
 });


### PR DESCRIPTION
## Pre-ramble

This is in prep for a PR to go back into the main Recharts repository. I have a feeling that we're going to need to wait until after they complete the `beta` upgrade that they're in the process of doing at the moment, however.

Once that is complete, we can bump this repo to the latest master and then look to get a PR ready to be merged in.

## PR content

Adds the ability to pass an `onDoubleClick` prop to the charts in the same way that single clicks are implemented.

Also updates the `package-lock.json` file with the automatic changes after running an `npm install`.
